### PR TITLE
Fix Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,15 @@ RUN python3 -m pip install --no-cache-dir -U pip
 # 1️⃣  PyTorch family from CUDA-12.1 index
 RUN python3 -m pip install --no-cache-dir \
       --index-url https://download.pytorch.org/whl/cu121 \
-      torch==2.3.1 \
-      torchvision==0.18.1 \
-      torchaudio==2.3.1
+      torch==2.4.1 \
+      torchvision==0.19.1 \
+      torchaudio==2.4.1
 
 # 2️⃣  Back to default index for remaining deps
 COPY requirements.txt /tmp/
 RUN python3 -m pip install --no-cache-dir \
       --extra-index-url https://download.pytorch.org/whl/cu121 \
-      xformers==0.0.27 && \
+      xformers==0.0.28 && \
     python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
 # ---------- Pre-download model weights --------------------------------


### PR DESCRIPTION
## Summary
- upgrade PyTorch dependencies in Dockerfile to 2.4 series
- update xformers version to 0.0.28 to match new torch

## Testing
- `pip install --no-cache-dir xformers==0.0.28 torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1 -U`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_688c7a7221c883289f80352ec10dc4d4