### PR TITLE
Fix Docker build failure with HF token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,25 @@ RUN python3 -m pip install --no-cache-dir \
     python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
 # ---------- Pre-download model weights --------------------------------
+ARG HF_TOKEN=""
 RUN python3 - <<'PY'
+import os
 from huggingface_hub import snapshot_download
-snapshot_download("stabilityai/stable-diffusion-xl-base-1.0",
-                  local_dir="/models/sdxl", revision="fp16", max_workers=8)
-snapshot_download("InstantX/InstantID",
-                  local_dir="/models/instantid", max_workers=8)
+
+token = os.getenv("HF_TOKEN") or None
+snapshot_download(
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    local_dir="/models/sdxl",
+    revision="fp16",
+    max_workers=8,
+    token=token,
+)
+snapshot_download(
+    "InstantX/InstantID",
+    local_dir="/models/instantid",
+    max_workers=8,
+    token=token,
+)
 PY
 
 ENV MODEL_DIR=/models

--- a/README.md
+++ b/README.md
@@ -237,10 +237,12 @@ The response contains a base64 encoded PNG under the `image` field.
 **Warning:** For simplicity, `app/main.py` disables the Stable Diffusion safety checker. Generated images might include NSFW content. Enable the safety checker or add your own content filtering when deploying this in production.
 
 ## Docker Build & Salad Deployment
-Use the provided `Dockerfile` to build a container image:
+Use the provided `Dockerfile` to build a container image. The build step
+downloads model weights from Hugging Face, which requires an access token. Pass
+your token via the `HF_TOKEN` build argument:
 
 ```bash
-docker build -t myname/instantid .
+docker build --build-arg HF_TOKEN=YOUR_HF_TOKEN -t myname/instantid .
 docker run -p 8000:8000 myname/instantid
 ```
 


### PR DESCRIPTION
## Summary
- require `HF_TOKEN` build arg for downloading models during Docker build
- document the new build flag in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688c84ba7ccc8328a00ee572c67c9f37