### PR TITLE
Fix stable diffusion download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ token = os.getenv("HF_TOKEN") or None
 snapshot_download(
     "stabilityai/stable-diffusion-xl-base-1.0",
     local_dir="/models/sdxl",
-    revision="fp16",
     max_workers=8,
     token=token,
 )


### PR DESCRIPTION
## Summary
- fix SDXL base weights download command by removing invalid `fp16` revision argument

## Testing
- `python3 -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688c8b0bdc3483289cb334635bba0d24