### PR TITLE
Use pre-downloaded models for InstantID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,27 +29,10 @@ RUN python3 -m pip install --no-cache-dir \
       xformers==0.0.28 && \
     python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
-# ---------- Pre-download model weights --------------------------------
-ARG HF_TOKEN=""
-RUN python3 - <<'PY'
-import os
-from huggingface_hub import snapshot_download
-
-token = os.getenv("HF_TOKEN") or None
-snapshot_download(
-    "stabilityai/stable-diffusion-xl-base-1.0",
-    local_dir="/models/sdxl",
-    max_workers=8,
-    token=token,
-)
-snapshot_download(
-    "InstantX/InstantID",
-    local_dir="/models/instantid",
-    max_workers=8,
-    token=token,
-)
-PY
-
+# ---------- Model directory -------------------------------------------
+# Models are expected to be mounted at runtime under /models.  Adjust the
+# path with the MODELS environment variable when launching the container
+# if necessary.
 ENV MODEL_DIR=/models
 
 # ---------- Copy your service code ------------------------------------

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mkdir -p models/antelopev2
 wget -O models/antelopev2/model.onnx https://example.com/path/to/antelopev2.onnx
 ```
 
-This file **must** exist prior to running `docker build`. Once you have prepared all models, the folder tree should look like:
+This file **must** exist prior to running the container. Once you have prepared all models, the folder tree should look like:
 
 ```
   .
@@ -237,18 +237,17 @@ The response contains a base64 encoded PNG under the `image` field.
 **Warning:** For simplicity, `app/main.py` disables the Stable Diffusion safety checker. Generated images might include NSFW content. Enable the safety checker or add your own content filtering when deploying this in production.
 
 ## Docker Build & Salad Deployment
-Use the provided `Dockerfile` to build a container image. The build step
-downloads model weights from Hugging Face, which requires an access token. Pass
-your token via the `HF_TOKEN` build argument:
+Use the provided `Dockerfile` to build a container image. Model weights are not
+downloaded during the build—mount them at runtime instead. The default location
+inside the container is `/models` and can be overridden with the `MODELS`
+environment variable.
 
 ```bash
-docker build --build-arg HF_TOKEN=YOUR_HF_TOKEN -t myname/instantid .
-docker run -p 8000:8000 myname/instantid
+docker build -t myname/instantid .
+docker run -p 8000:8000 -v /absolute/path/to/models:/models myname/instantid
 ```
 
 The GitHub Actions workflow [`image.yml`](.github/workflows/image.yml) shows how the project automatically builds and pushes this image and then deploys it to [Salad](https://salad.com) using their API.
-
-Before building, manually download the **antelopev2** face encoder to `models/antelopev2` so the container has everything it needs at runtime.
 
 ## Community Resources
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,9 @@ from diffusers.models import ControlNetModel
 from insightface.app import FaceAnalysis
 
 # ── constants ──────────────────────────────────────────────────────────
-MODELS = "/models"                      # baked into the Docker image
+# Location of model weights. Override with the MODELS environment variable
+# when launching the container if your models live elsewhere.
+MODELS = os.getenv("MODELS", "/models")
 DEVICE  = "cuda" if torch.cuda.is_available() else "cpu"
 
 # ── load InstantID pipeline once at startup ────────────────────────────


### PR DESCRIPTION
## Summary
- Allow overriding model directory via MODELS environment variable
- Remove model downloads from Dockerfile; expect models to be mounted at runtime
- Document volume mount workflow and updated build instructions

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688c97227fe88328bf48bdd7ec221e92