### PR TITLE
feat: make model path configurable

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -1,3 +1,4 @@
+import os
 import cv2
 import torch
 import numpy as np
@@ -8,6 +9,9 @@ from diffusers.models import ControlNetModel
 
 from insightface.app import FaceAnalysis
 from pipeline_stable_diffusion_xl_instantid import StableDiffusionXLInstantIDPipeline, draw_kps
+
+
+MODELS = os.getenv("MODELS", "./checkpoints")
 
 def resize_img(input_image, max_side=1280, min_side=1024, size=None, 
                pad_to_max_side=False, mode=Image.BILINEAR, base_pixel_number=64):
@@ -36,17 +40,17 @@ def resize_img(input_image, max_side=1280, min_side=1024, size=None,
 if __name__ == "__main__":
 
     # Load face encoder
-    app = FaceAnalysis(name='antelopev2', root='./', providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+    app = FaceAnalysis(name='antelopev2', root=MODELS, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
     app.prepare(ctx_id=0, det_size=(640, 640))
 
     # Path to InstantID models
-    face_adapter = f'./checkpoints/ip-adapter.bin'
-    controlnet_path = f'./checkpoints/ControlNetModel'
+    face_adapter = f'{MODELS}/instantid/ip-adapter.bin'
+    controlnet_path = f'{MODELS}/instantid/ControlNetModel'
 
     # Load pipeline
     controlnet = ControlNetModel.from_pretrained(controlnet_path, torch_dtype=torch.float16)
 
-    base_model_path = 'stabilityai/stable-diffusion-xl-base-1.0'
+    base_model_path = f'{MODELS}/sdxl'
 
     pipe = StableDiffusionXLInstantIDPipeline.from_pretrained(
         base_model_path,


### PR DESCRIPTION
## Summary
- read model root from MODELS env var
- switch to local model paths for FaceAnalysis and InstantID pipeline

## Testing
- `python -m py_compile infer.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5172d8d883289aad9d8f546cc58a