### PR TITLE
Fix missing onnxruntime dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ diffusers>=0.27.0
 transformers>=4.41.0
 accelerate>=0.28.0
 insightface==0.7
+onnxruntime-gpu==1.17.1
+numpy<2
 controlnet_aux>=0.0.6
 fastapi==0.111.0
 uvicorn[standard]==0.30.0


### PR DESCRIPTION
## Summary
- add `onnxruntime-gpu` dependency for insightface
- pin `numpy<2` to maintain compatibility

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 - <<'PY'
from insightface.app import FaceAnalysis
print('insightface loaded successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689030b24e5883289a9adcedda3f4589