### PR TITLE
Add fallback model downloads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ controlnet_aux>=0.0.6
 fastapi==0.111.0
 uvicorn[standard]==0.30.0
 pillow
+huggingface-hub


### PR DESCRIPTION
## Summary
- load ControlNet from local path if available otherwise download from Hugging Face
- fetch ip-adapter weights dynamically when missing
- include huggingface-hub dependency

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905d6f417c83289daaa3f4a8d3f942