### PR TITLE
Handle default Windows model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,9 @@ The response contains a base64 encoded PNG under the `image` field.
 ## Docker Build & Salad Deployment
 Use the provided `Dockerfile` to build a container image. Model weights are not
 downloaded during the build—mount them at runtime instead. The default location
-inside the container is `/models` and can be overridden with the `MODELS`
-environment variable.
+inside the Linux container is `/models`. When running on Windows outside a
+container, the scripts look for models under `C:\\models`. In either case you
+can override the location by setting the `MODELS` environment variable.
 
 ```bash
 docker build -t myname/instantid .

--- a/app/main.py
+++ b/app/main.py
@@ -8,8 +8,11 @@ from huggingface_hub import hf_hub_download
 
 # ── constants ──────────────────────────────────────────────────────────
 # Location of model weights. Override with the MODELS environment variable
-# when launching the container if your models live elsewhere.
-MODELS = os.getenv("MODELS", "/models")
+# when launching the container if your models live elsewhere. Default to a
+# Windows-friendly path when running on Windows, otherwise use the Linux
+# container default.
+default_models_dir = "C:\\models" if os.name == "nt" else "/models"
+MODELS = os.getenv("MODELS", default_models_dir)
 DEVICE  = "cuda" if torch.cuda.is_available() else "cpu"
 
 # ── load InstantID pipeline once at startup ────────────────────────────
@@ -32,8 +35,9 @@ else:
         torch_dtype=torch.float16,
     )
 
+base_model_path = os.path.join(MODELS, "sdxl")
 pipe = StableDiffusionXLInstantIDPipeline.from_pretrained(
-    f"{MODELS}/sdxl",
+    base_model_path,
     controlnet=controlnet,
     torch_dtype=torch.float16,
     variant="fp16",

--- a/infer.py
+++ b/infer.py
@@ -11,7 +11,8 @@ from insightface.app import FaceAnalysis
 from pipeline_stable_diffusion_xl_instantid import StableDiffusionXLInstantIDPipeline, draw_kps
 
 
-MODELS = os.getenv("MODELS", "./checkpoints")
+default_models_dir = "C:\\models" if os.name == "nt" else "./checkpoints"
+MODELS = os.getenv("MODELS", default_models_dir)
 
 def resize_img(input_image, max_side=1280, min_side=1024, size=None, 
                pad_to_max_side=False, mode=Image.BILINEAR, base_pixel_number=64):
@@ -44,13 +45,13 @@ if __name__ == "__main__":
     app.prepare(ctx_id=0, det_size=(640, 640))
 
     # Path to InstantID models
-    face_adapter = f'{MODELS}/instantid/ip-adapter.bin'
-    controlnet_path = f'{MODELS}/instantid/ControlNetModel'
+    face_adapter = os.path.join(MODELS, 'instantid', 'ip-adapter.bin')
+    controlnet_path = os.path.join(MODELS, 'instantid', 'ControlNetModel')
 
     # Load pipeline
     controlnet = ControlNetModel.from_pretrained(controlnet_path, torch_dtype=torch.float16)
 
-    base_model_path = f'{MODELS}/sdxl'
+    base_model_path = os.path.join(MODELS, 'sdxl')
 
     pipe = StableDiffusionXLInstantIDPipeline.from_pretrained(
         base_model_path,


### PR DESCRIPTION
## Summary
- default model root to `C:\models` on Windows for local runs
- build model and adapter paths with `os.path.join`
- document model path defaults and `MODELS` override

## Testing
- `python -m py_compile app/main.py infer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689071b5b8a88328a23be2a79e7e8d9a